### PR TITLE
Update documentos_obligatorios migration data

### DIFF
--- a/backend/database/migrations/2025_08_29_002723_create_documentos_obligatorios.php
+++ b/backend/database/migrations/2025_08_29_002723_create_documentos_obligatorios.php
@@ -20,13 +20,19 @@ return new class extends Migration
         DB::table('documentos_obligatorios')->insert([
             [
                 'nombre_doc' => 'ESCRITURA MUTUO',
-                'analizar' => true,
+                'analizar' => 1,
                 'created_at' => now(),
                 'updated_at' => now(),
             ],
             [
-                'nombre_doc' => 'CARNET IDENTIDAD',
-                'analizar' => false,
+                'nombre_doc' => 'CARNET IDENTIDAD DEUDOR',
+                'analizar' => 0,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'nombre_doc' => 'CARNET IDENTIDAD CODEUDOR',
+                'analizar' => 0,
                 'created_at' => now(),
                 'updated_at' => now(),
             ],


### PR DESCRIPTION
Changed 'analizar' field values from boolean to integer for consistency. Updated document names for identity documents and added a new entry for 'CARNET IDENTIDAD CODEUDOR'.